### PR TITLE
fixed:routes.rbの余計な記述削除

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount ActionCable.server => "/cable"
+  # mount ActionCable.server => "/cable"
   resources :messages
   root "messages#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
- routes.rbに「mount ActionCable.server => "/cable"」と書いたが、デフォルトでこの設定になっているらしいので削除した。